### PR TITLE
chore: update Scala version to 2.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: scala
 scala:
-  - 2.11.8
+  - 2.12.1

--- a/build.sbt
+++ b/build.sbt
@@ -2,21 +2,22 @@ name := "openid-scala"
 
 version := "1.0"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.1"
+crossScalaVersions := Seq("2.11.8", "2.12.1")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka"             %%  "akka-actor"                        % "2.4.11",
-  "com.typesafe.akka"             %%  "akka-stream"                       % "2.4.11",
-  "com.typesafe.akka"             %%  "akka-http-core"                    % "2.4.11",
-  "com.typesafe.akka"             %%  "akka-http-experimental"            % "2.4.11",
-  "com.typesafe.akka"             %%  "akka-http-testkit"                 % "2.4.11" % Test,
-  "com.typesafe.akka"             %%  "akka-http-spray-json-experimental" % "2.4.11",
-  "org.mockito"                   %   "mockito-core"                      % "2.5.0" % Test,
-  "org.scalactic"                 %%  "scalactic"                         % "3.0.1" % Test,
-  "org.specs2"                    %%  "specs2-core"                       % "3.8.5.1" % Test,
-  "org.specs2"                    %%  "specs2-matcher"                    % "3.8.5.1" % Test,
-  "org.specs2"                    %%  "specs2-matcher-extra"              % "3.8.5.1" % Test,
-  "org.specs2"                    %%  "specs2-mock"                       % "3.8.5.1" % Test
+  "com.typesafe.akka"             %%  "akka-actor"           % "2.4.17",
+  "com.typesafe.akka"             %%  "akka-stream"          % "2.4.17",
+  "com.typesafe.akka"             %%  "akka-http"            % "10.0.5",
+  "com.typesafe.akka"             %%  "akka-http-core"       % "10.0.5",
+  "com.typesafe.akka"             %%  "akka-http-testkit"    % "10.0.5" % Test,
+  "com.typesafe.akka"             %%  "akka-http-spray-json" % "10.0.5",
+  "org.mockito"                   %   "mockito-core"         % "2.5.0" % Test,
+  "org.scalactic"                 %%  "scalactic"            % "3.0.1" % Test,
+  "org.specs2"                    %%  "specs2-core"          % "3.8.9" % Test,
+  "org.specs2"                    %%  "specs2-matcher"       % "3.8.9" % Test,
+  "org.specs2"                    %%  "specs2-matcher-extra" % "3.8.9" % Test,
+  "org.specs2"                    %%  "specs2-mock"          % "3.8.9" % Test
 )
 
 logBuffered in Test := false


### PR DESCRIPTION
Scala version bumped to `2.12.1` together with dependent modules.